### PR TITLE
flush: wrong number of arguments to _retryRequest

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ class KintoServer {
 
   flush(attempt = 1) {
     const endpoint = `${this.url}/__flush__`;
-    return this._retryRequest(endpoint, {method: "POST"}, {}, 1);
+    return this._retryRequest(endpoint, {method: "POST"}, 1);
   }
 
   stop() {


### PR DESCRIPTION
This made it harder to diagnose and understand
https://github.com/Kinto/kinto-http.js/pull/166.