### PR TITLE
Add Windows support

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,7 +105,11 @@ class KintoServer {
 
   killAll() {
     return new Promise(resolve => {
-      spawn("killall", ["pserve"]).on("close", () => resolve());
+      if (process.platform === "win32") {
+        spawn("taskkill", ["/im", "pserve.exe"]).on("close", () => resolve());
+      } else {
+        spawn("killall", ["pserve"]).on("close", () => resolve());
+      }
     });
   }
 }


### PR DESCRIPTION
`killall` isn't available on Windows, so this PR adds a conditional for detecting Windows and using a similar command to kill `pserve`.

This change is necessary to run the `kinto-http.js` test suite on Windows.