### PR TITLE
Add TypeScript declaration file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,19 @@
+export interface KintoServerOptions {
+    maxAttempts?: number;
+    pservePath?: string;
+    kintoConfigPath?: string;
+}
+export declare class KintoServer {
+    private url;
+    private process;
+    private logs;
+    http_api_version: string | null;
+    private options;
+    constructor(url: string, options?: KintoServerOptions);
+    private _retryRequest;
+    start(env: Record<string, string>): Promise<void>;
+    ping(): Promise<void>;
+    flush(): Promise<void>;
+    stop(): Promise<void>;
+    killAll(): Promise<void>;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,19 +1,19 @@
 export interface KintoServerOptions {
-    maxAttempts?: number;
-    pservePath?: string;
-    kintoConfigPath?: string;
+  maxAttempts?: number;
+  pservePath?: string;
+  kintoConfigPath?: string;
 }
 export declare class KintoServer {
-    private url;
-    private process;
-    private logs;
-    http_api_version: string | null;
-    private options;
-    constructor(url: string, options?: KintoServerOptions);
-    private _retryRequest;
-    start(env: Record<string, string>): Promise<void>;
-    ping(): Promise<void>;
-    flush(): Promise<void>;
-    stop(): Promise<void>;
-    killAll(): Promise<void>;
+  private url;
+  private process;
+  private logs;
+  http_api_version: string | null;
+  private options;
+  constructor(url: string, options?: KintoServerOptions);
+  private _retryRequest;
+  start(env: Record<string, string>): Promise<void>;
+  ping(): Promise<void>;
+  flush(): Promise<void>;
+  stop(): Promise<void>;
+  killAll(): Promise<void>;
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.4",
   "description": "A node API for operating a Kinto test server.",
   "main": "index.js",
+  "types": "index.d.ts",
   "engines": {
     "node": ">=6"
   },


### PR DESCRIPTION
This PR adds a TypeScript definition file so that TypeScript consumers can get type-checking.

This was generated by rewriting the library in TypeScript, and then copying over the emitted declaration file. This PR does not convert the library to TypeScript, but just in case that is ever something we want to do, there's a copy of the TypeScript version [here](https://gist.github.com/dstaley/d7b7d5c2d2ebe6f130676b657302245f).